### PR TITLE
Update RoseTTAFold-linux-cu101.yml

### DIFF
--- a/RoseTTAFold-linux-cu101.yml
+++ b/RoseTTAFold-linux-cu101.yml
@@ -13,7 +13,7 @@ dependencies:
   - biopython=1.78=py38h497a2fe_2
   - blas=1.0=mkl
   - hhsuite
-  - blast-legacy=2.2.26=2
+  - biocore::blast-legacy=2.2.26
   - brotlipy=0.7.0=py38h497a2fe_1001
   - bzip2=1.0.8=h7b6447c_0
   - ca-certificates=2021.7.5=h06a4308_1


### PR DESCRIPTION
https://github.com/RosettaCommons/RoseTTAFold/blob/d0de739a1ef9193ff1c671a646683ffe5979b56b/RoseTTAFold-linux.yml#L12

`conda install biocore::blast-legacy=2.2.26`
will show 
"export BLASTMAT=~/.conda/RoseTTAFoldcu101/share/blast-2.2.26/data/" after install also have the BLOSUM files under the folder. 

however 

`conda install blast-legacy=2.2.26=2`
as https://github.com/RosettaCommons/RoseTTAFold/blob/d0de739a1ef9193ff1c671a646683ffe5979b56b/RoseTTAFold-linux-cu101.yml#L16 
won't because it install the bioconda version bioconda/linux-64::blast-legacy-2.2.26-2 

so it's a small difference between RoseTTAFold-linux-cu101.yml and RoseTTAFold-linux.yml