### PR TITLE
Let CUDA decide which GPU to use

### DIFF
--- a/DAN-msa/ErrorPredictorMSA.py
+++ b/DAN-msa/ErrorPredictorMSA.py
@@ -114,6 +114,7 @@ def main():
     ##############################
     os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
     if args.gpu is not None:
+        assert type(args.gpu) == int, 'GPU id must be specified as int, e.g. 0'
         os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
     script_dir = os.path.dirname(__file__)
     sys.path.insert(0, script_dir)

--- a/DAN-msa/ErrorPredictorMSA.py
+++ b/DAN-msa/ErrorPredictorMSA.py
@@ -46,9 +46,8 @@ def main():
                         help="# of cpus to use for featurization (Default: 1)")
     parser.add_argument("--gpu",
                         "-g", action="store",
-                        type=int,
-                        default=0,
-                        help="gpu device to use (default gpu0)")
+                        default=None,
+                        help="specific gpu id to use, e.g. 0 for gpu0 (Default: None)")
     parser.add_argument("--featurize",
                         "-f",
                         action="store_true",
@@ -114,7 +113,8 @@ def main():
     # Importing larger libraries #
     ##############################
     os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
+    if args.gpu is not None:
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(args.gpu)
     script_dir = os.path.dirname(__file__)
     sys.path.insert(0, script_dir)
     import pyErrorPred

--- a/run_pyrosetta_ver.sh
+++ b/run_pyrosetta_ver.sh
@@ -115,7 +115,7 @@ count=$(find $WDIR/pdb-3track -maxdepth 1 -name '*.npz' | grep -v 'features' | w
 if [ "$count" -lt "15" ]; then
     # run DeepAccNet-msa
     echo "Running DeepAccNet-msa"
-    python $PIPEDIR/DAN-msa/ErrorPredictorMSA.py --roll -g $GPU_ID -p $CPU $WDIR/t000_.3track.npz $WDIR/pdb-3track $WDIR/pdb-3track 1> $WDIR/log/DAN_msa.stdout 2> $WDIR/log/DAN_msa.stderr
+    python $PIPEDIR/DAN-msa/ErrorPredictorMSA.py --roll -p $CPU $WDIR/t000_.3track.npz $WDIR/pdb-3track $WDIR/pdb-3track 1> $WDIR/log/DAN_msa.stdout 2> $WDIR/log/DAN_msa.stderr
 fi
 
 if [ ! -s $WDIR/model/model_5.crderr.pdb ]

--- a/run_pyrosetta_ver.sh
+++ b/run_pyrosetta_ver.sh
@@ -15,6 +15,7 @@ unset __conda_setup
 SCRIPT=`realpath -s $0`
 export PIPEDIR=`dirname $SCRIPT`
 
+GPU_ID="" # which gpu to use (int), for example 0 for gpu0
 CPU="8"  # number of CPUs to use
 MEM="64" # max memory (in GB)
 
@@ -22,6 +23,10 @@ MEM="64" # max memory (in GB)
 IN="$1"                # input.fasta
 WDIR=`realpath -s $2`  # working folder
 
+if [ ! -z "$GPU_ID" ]
+  then
+    export CUDA_VISIBLE_DEVICES=$GPU_ID
+fi
 
 LEN=`tail -n1 $IN | wc -m`
 
@@ -110,7 +115,7 @@ count=$(find $WDIR/pdb-3track -maxdepth 1 -name '*.npz' | grep -v 'features' | w
 if [ "$count" -lt "15" ]; then
     # run DeepAccNet-msa
     echo "Running DeepAccNet-msa"
-    python $PIPEDIR/DAN-msa/ErrorPredictorMSA.py --roll -p $CPU $WDIR/t000_.3track.npz $WDIR/pdb-3track $WDIR/pdb-3track 1> $WDIR/log/DAN_msa.stdout 2> $WDIR/log/DAN_msa.stderr
+    python $PIPEDIR/DAN-msa/ErrorPredictorMSA.py --roll -g $GPU_ID -p $CPU $WDIR/t000_.3track.npz $WDIR/pdb-3track $WDIR/pdb-3track 1> $WDIR/log/DAN_msa.stdout 2> $WDIR/log/DAN_msa.stderr
 fi
 
 if [ ! -s $WDIR/model/model_5.crderr.pdb ]

--- a/run_pyrosetta_ver.sh
+++ b/run_pyrosetta_ver.sh
@@ -15,7 +15,7 @@ unset __conda_setup
 SCRIPT=`realpath -s $0`
 export PIPEDIR=`dirname $SCRIPT`
 
-GPU_ID="" # which gpu to use (int), for example 0 for gpu0
+GPU_ID="" # which gpu to use (int), for example 0 for gpu0. if none provided, it will let CUDA decide
 CPU="8"  # number of CPUs to use
 MEM="64" # max memory (in GB)
 


### PR DESCRIPTION
Previously the default GPU gpu0 is always used in the script. 
This small change allows you to chose another GPU and also makes sure DAN-msa doesn't just use gpu0 as default, which then doesn't allow CUDA to distribute the workload itself, which results in OOM errors in case that GPU is busy, even when other GPUs might be idle. 