### PR TITLE
Add Docker container image that is also compatible with Singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,29 +2,24 @@ FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 ARG ROSETTACOMMONS_CONDA_USERNAME
 ARG ROSETTACOMMONS_CONDA_PASSWORD
 
-ENV PATH="/var/conda/miniconda3/bin:${PATH}"
-ARG PATH="/var/conda/miniconda3/bin:${PATH}"
-
-
 RUN apt-get update
 
 RUN apt-get install -y wget libgomp1 && rm -rf /var/lib/apt/lists/*
 
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && mkdir /var/conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b -p /var/conda\
     && rm -f Miniconda3-latest-Linux-x86_64.sh
 
-ENV PATH /opt/conda/bin:$PATH
+ENV PATH /var/conda/bin:$PATH
 
 RUN conda --version
 
 COPY . /RoseTTaFold
 WORKDIR /RoseTTaFold
 
-RUN conda env create -f RoseTTAFold-linux.yml
-RUN conda env create -f folding-linux.yml
+RUN conda env create -q -f RoseTTAFold-linux.yml
+RUN conda env create -q -f folding-linux.yml
 
 RUN conda config --add channels https://${ROSETTACOMMONS_CONDA_USERNAME}:${ROSETTACOMMONS_CONDA_PASSWORD}@conda.graylab.jhu.edu
 #installing pyrosetta into a base image so it gets cached between builds
@@ -35,3 +30,5 @@ RUN tar xfz weights.tar.gz
 RUN ./install_dependencies.sh
 RUN ln -s /RoseTTaFold/run_e2e_ver.sh /usr/local/bin/run_e2e_ver.sh
 RUN ln -s /RoseTTaFold/run_pyrosetta_ver.sh /usr/local/bin/run_pyrosetta_ver.sh
+
+WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+ARG ROSETTACOMMONS_CONDA_USERNAME
+ARG ROSETTACOMMONS_CONDA_PASSWORD
 
 ENV PATH="/root/miniconda3/bin:${PATH}"
 ARG PATH="/root/miniconda3/bin:${PATH}"
 
+
 RUN apt-get update
 
-RUN apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y wget libgomp1 && rm -rf /var/lib/apt/lists/*
 
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
@@ -19,6 +22,10 @@ WORKDIR /RoseTTaFold
 
 RUN conda env create -f RoseTTAFold-linux.yml
 RUN conda env create -f folding-linux.yml
+
+RUN conda config --add channels https://ROSETTACOMMONS_CONDA_USERNAME:ROSETTACOMMONS_CONDA_PASSWORD@conda.graylab.jhu.edu
+#installing pyrosetta into a base image so it gets cached between builds
+RUN conda install -n folding pyrosetta=2020.45
 
 RUN wget https://files.ipd.uw.edu/pub/RoseTTAFold/weights.tar.gz
 RUN tar xfz weights.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,10 @@ RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && mkdir /var/conda \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh 
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH /opt/conda/bin:$PATH
+
 RUN conda --version
 
 COPY . /RoseTTaFold

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ROSETTACOMMONS_CONDA_PASSWORD
 
 RUN apt-get update
 
-RUN apt-get install -y wget libgomp1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get install -y wget libgomp1 unzip && rm -rf /var/lib/apt/lists/*
 
 RUN wget -q \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 ARG ROSETTACOMMONS_CONDA_USERNAME
 ARG ROSETTACOMMONS_CONDA_PASSWORD
 
-ENV PATH="/var/miniconda3/bin:${PATH}"
-ARG PATH="/var/miniconda3/bin:${PATH}"
+ENV PATH="/var/conda/miniconda3/bin:${PATH}"
+ARG PATH="/var/conda/miniconda3/bin:${PATH}"
 
 
 RUN apt-get update

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN conda install -n folding pyrosetta=2020.45
 RUN wget -q https://files.ipd.uw.edu/pub/RoseTTAFold/weights.tar.gz
 RUN tar xfz weights.tar.gz
 RUN ./install_dependencies.sh
-RUN ln -s /RoseTTaFold/run_e2e_ver.sh /usr/local/bin/run_e2e_ver.sh
-RUN ln -s /RoseTTaFold/run_pyrosetta_ver.sh /usr/local/bin/run_pyrosetta_ver.sh
+
+ENV PATH /RoseTTaFold:$PATH
 
 WORKDIR /tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+FROM nvcr.io/nvidia/cuda:11.3.0-cudnn8-runtime-ubuntu20.04
 ARG ROSETTACOMMONS_CONDA_USERNAME
 ARG ROSETTACOMMONS_CONDA_PASSWORD
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 
 RUN apt-get install -y wget libgomp1 && rm -rf /var/lib/apt/lists/*
 
-RUN wget \
+RUN wget -q \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && bash Miniconda3-latest-Linux-x86_64.sh -b -p /var/conda\
     && rm -f Miniconda3-latest-Linux-x86_64.sh
@@ -25,7 +25,7 @@ RUN conda config --add channels https://${ROSETTACOMMONS_CONDA_USERNAME}:${ROSET
 #installing pyrosetta into a base image so it gets cached between builds
 RUN conda install -n folding pyrosetta=2020.45
 
-RUN wget https://files.ipd.uw.edu/pub/RoseTTAFold/weights.tar.gz
+RUN wget -q https://files.ipd.uw.edu/pub/RoseTTAFold/weights.tar.gz
 RUN tar xfz weights.tar.gz
 RUN ./install_dependencies.sh
 RUN ln -s /RoseTTaFold/run_e2e_ver.sh /usr/local/bin/run_e2e_ver.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
+
+ENV PATH="/root/miniconda3/bin:${PATH}"
+ARG PATH="/root/miniconda3/bin:${PATH}"
+
+RUN apt-get update
+
+RUN apt-get install -y wget && rm -rf /var/lib/apt/lists/*
+
+RUN wget \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh 
+RUN conda --version
+
+COPY . /RoseTTaFold
+WORKDIR /RoseTTaFold
+
+RUN conda env create -f RoseTTAFold-linux.yml
+RUN conda env create -f folding-linux.yml
+
+RUN wget https://files.ipd.uw.edu/pub/RoseTTAFold/weights.tar.gz
+RUN tar xfz weights.tar.gz
+RUN ./install_dependencies.sh
+RUN ln -s /RoseTTaFold/run_e2e_ver.sh /usr/local/bin/run_e2e_ver.sh
+RUN ln -s /RoseTTaFold/run_pyrosetta_ver.sh /usr/local/bin/run_pyrosetta_ver.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM nvcr.io/nvidia/cuda:11.4.1-cudnn8-runtime-ubuntu20.04
 ARG ROSETTACOMMONS_CONDA_USERNAME
 ARG ROSETTACOMMONS_CONDA_PASSWORD
 
-ENV PATH="/root/miniconda3/bin:${PATH}"
-ARG PATH="/root/miniconda3/bin:${PATH}"
+ENV PATH="/var/miniconda3/bin:${PATH}"
+ARG PATH="/var/miniconda3/bin:${PATH}"
 
 
 RUN apt-get update
@@ -12,7 +12,7 @@ RUN apt-get install -y wget libgomp1 && rm -rf /var/lib/apt/lists/*
 
 RUN wget \
     https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
-    && mkdir /root/.conda \
+    && mkdir /var/conda \
     && bash Miniconda3-latest-Linux-x86_64.sh -b \
     && rm -f Miniconda3-latest-Linux-x86_64.sh 
 RUN conda --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /RoseTTaFold
 RUN conda env create -f RoseTTAFold-linux.yml
 RUN conda env create -f folding-linux.yml
 
-RUN conda config --add channels https://ROSETTACOMMONS_CONDA_USERNAME:ROSETTACOMMONS_CONDA_PASSWORD@conda.graylab.jhu.edu
+RUN conda config --add channels https://${ROSETTACOMMONS_CONDA_USERNAME}:${ROSETTACOMMONS_CONDA_PASSWORD}@conda.graylab.jhu.edu
 #installing pyrosetta into a base image so it gets cached between builds
 RUN conda install -n folding pyrosetta=2020.45
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,7 +17,6 @@ resources:
   - repo: self
 
 stages:
-
 - stage: build
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
   jobs:
@@ -25,6 +24,7 @@ stages:
     workspace:
       clean: all # what to clean up before the job runs
     pool: Custom
+    timeoutInMinutes: 90
     steps:
 
     - task: Docker@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ stages:
         containerRegistry: 'neoleukin-container-registry'
         repository: 'rosettafold'
         command: 'buildAndPush'
+        arguments: --secret ROSETTACOMMONS_CONDA_USERNAME=$(ROSETTACOMMONS_CONDA_USERNAME)  ROSETTACOMMONS_CONDA_PASSWORD=$(ROSETTACOMMONS_CONDA_PASSWORD)
         Dockerfile: 'Dockerfile'
         tags: |
           $(Build.SourceBranchName)-$(Build.BuildId)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ stages:
 
     - task: Docker@2
       inputs:
-        containerRegistry: 'neoleukin-container-registry'
+        containerRegistry: $(ACR_CONTAINER_REGISTRY)
         repository: 'rosettafold'
         command: 'build'
         arguments: --build-arg ROSETTACOMMONS_CONDA_USERNAME=$(ROSETTACOMMONS_CONDA_USERNAME) --build-arg ROSETTACOMMONS_CONDA_PASSWORD=$(ROSETTACOMMONS_CONDA_PASSWORD)
@@ -41,7 +41,7 @@ stages:
           $(Build.SourceBranchName) 
     - task: Docker@2
       inputs:
-        containerRegistry: 'neoleukin-container-registry'
+        containerRegistry: $(ACR_CONTAINER_REGISTRY)
         repository: 'rosettafold'
         command: 'push'
         Dockerfile: 'Dockerfile'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,39 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+  tags:
+    include:
+    - v*
+  branches:
+    include:
+    - main
+    - feature/*
+    - bugfix/*
+
+resources:
+  - repo: self
+
+stages:
+
+- stage: build
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  jobs:
+  - job:
+    workspace:
+      clean: all # what to clean up before the job runs
+    pool: Custom
+    steps:
+    - task: Docker@2
+      inputs:
+        containerRegistry: 'neoleukin-container-registry'
+        repository: 'rosettafold'
+        command: 'buildAndPush'
+        Dockerfile: 'Dockerfile'
+        tags: |
+          $(Build.SourceBranchName)-$(Build.BuildId)
+          $(Build.SourceBranchName)-$(Build.SourceVersion)
+          $(Build.SourceBranchName)-latest
+          $(Build.SourceBranchName) 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,24 @@ stages:
       clean: all # what to clean up before the job runs
     pool: Custom
     steps:
+
     - task: Docker@2
       inputs:
         containerRegistry: 'neoleukin-container-registry'
         repository: 'rosettafold'
-        command: 'buildAndPush'
-        arguments: --secret ROSETTACOMMONS_CONDA_USERNAME=$(ROSETTACOMMONS_CONDA_USERNAME)  ROSETTACOMMONS_CONDA_PASSWORD=$(ROSETTACOMMONS_CONDA_PASSWORD)
+        command: 'build'
+        arguments: --build-arg ROSETTACOMMONS_CONDA_USERNAME=$(ROSETTACOMMONS_CONDA_USERNAME) --build-arg ROSETTACOMMONS_CONDA_PASSWORD=$(ROSETTACOMMONS_CONDA_PASSWORD)
+        Dockerfile: 'Dockerfile'
+        tags: |
+          $(Build.SourceBranchName)-$(Build.BuildId)
+          $(Build.SourceBranchName)-$(Build.SourceVersion)
+          $(Build.SourceBranchName)-latest
+          $(Build.SourceBranchName) 
+    - task: Docker@2
+      inputs:
+        containerRegistry: 'neoleukin-container-registry'
+        repository: 'rosettafold'
+        command: 'push'
         Dockerfile: 'Dockerfile'
         tags: |
           $(Build.SourceBranchName)-$(Build.BuildId)

--- a/run_e2e_ver.sh
+++ b/run_e2e_ver.sh
@@ -15,8 +15,8 @@ unset __conda_setup
 SCRIPT=`realpath -s $0`
 export PIPEDIR=`dirname $SCRIPT`
 
-CPU="8"  # number of CPUs to use
-MEM="64" # max memory (in GB)
+CPU="${CPU:=8}"  # number of CPUs to use
+MEM="${MEM:=64}" # max memory (in GB)
 
 # Inputs:
 IN="$1"                # input.fasta

--- a/run_pyrosetta_ver.sh
+++ b/run_pyrosetta_ver.sh
@@ -15,8 +15,8 @@ unset __conda_setup
 SCRIPT=`realpath -s $0`
 export PIPEDIR=`dirname $SCRIPT`
 
-CPU="8"  # number of CPUs to use
-MEM="64" # max memory (in GB)
+CPU="${CPU:=8}"  # number of CPUs to use
+MEM="${MEM:=64}" # max memory (in GB)
 
 # Inputs:
 IN="$1"                # input.fasta


### PR DESCRIPTION
This PR adds a Dockerfile that creates a container with the necessary Conda environments and dependencies to run RoseTTaFold. The container doesn't include databases, the databases need to be mounted into the container at run time.

The container image requires credentials to the Commons Conda repo to install pyrosetta, this are passed at build time using build arguments.

```docker build  --build-arg ROSETTACOMMONS_CONDA_USERNAME=***** --build-arg ROSETTACOMMONS_CONDA_PASSWORD=******  -t rosettafold:main-latest .```

The azure-pipeline file can be used to configure a build pipeline in Azure for building the image.

example of how to run the container
```bash
# ROSETTAFOLDDB_PATH points to a folder with the databases untar'ed (bfd, pdb100_2021Mar03, UniRef30_2020_06)
export ROSETTAFOLDDB_PATH=/home/jcastellanos/RosettaFoldDBs


 docker run -it --gpus=all -v $ROSETTAFOLDDB_PATH/bfd:/RoseTTaFold/bfd -v $ROSETTAFOLDDB_PATH/pdb100_2021Mar03:/RoseTTaFold/pdb100_2021Mar03 -v  $ROSETTAFOLDDB_PATH/UniRef30_2020_06:/RoseTTaFold/UniRef30_2020_06 -v $(pwd):$(pwd) -w $(pwd) rosettafold:main-latest run_pyrosetta_ver.sh input.fa .
```

The container can also be run using singularity, in this example the image is pulled from a private registry in Azure.
```
 singularity run  --nv -B $ROSETTAFOLDDB_PATH/bfd:/RoseTTaFold/bfd -B  $ROSETTAFOLDDB_PATH/pdb100_2021Mar03:/RoseTTaFold/pdb100_2021Mar03 -B $ROSETTAFOLDDB_PATH/UniRef30_2020_06:/RoseTTaFold/UniRef30_2020_06 docker://private_registry.azurecr.io/rosettafold:main-latest run_pyrosetta_ver.sh input.fa .
```