### PR TITLE
fix permission errors on shared file systems

### DIFF
--- a/network/equivariant_attention/from_se3cnn/utils_steerable.py
+++ b/network/equivariant_attention/from_se3cnn/utils_steerable.py
@@ -33,7 +33,7 @@ def get_matrices_kernel(As, eps=1e-10):
     return get_matrix_kernel(torch.cat(As, dim=0), eps)
 
 
-@cached_dirpklgz("%s/cache/trans_Q"%os.path.dirname(os.path.realpath(__file__)))
+@cached_dirpklgz("%s/.cache/trans_Q"%os.path.expanduser('~'))
 def _basis_transformation_Q_J(J, order_in, order_out, version=3):  # pylint: disable=W0613
     """
     :param J: order of the spherical harmonics


### PR DESCRIPTION
Changes the cache directory path from the installation directory to the users home directory
to avoid a crash due to insufficient permissions.

Should fix #120 